### PR TITLE
Update how base path is added in the validator instantiation

### DIFF
--- a/openapi-archetype/src/main/archetype/src/generated/java/RoutesGenerated.java
+++ b/openapi-archetype/src/main/archetype/src/generated/java/RoutesGenerated.java
@@ -1,6 +1,8 @@
 package ${package};
 
 import javax.annotation.Generated;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import com.ms3_inc.camel.extensions.rest.OpenApi4jValidator;
 
@@ -12,9 +14,11 @@ import com.ms3_inc.camel.extensions.rest.OpenApi4jValidator;
 @Generated("com.ms3_inc.camel.archetype.oas")
 @Component
 public class RoutesGenerated extends BaseRestRouteBuilder{
+    private final String contextPath;
 
-    public RoutesGenerated() {
+    public RoutesGenerated(@Value("${camel.rest.context-path}") String contextPath) {
         super();
+        this.contextPath = contextPath;
     }
 
     /**

--- a/openapi-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/openapi-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -117,7 +117,7 @@ rGenCode = new StringBuffer()
 //	Add support for request validation.
 rGenCode.append(tabs(indent)+'interceptFrom()\n')
 indent = 3
-rGenCode.append(tabs(indent)+'.process(new OpenApi4jValidator("'+fileName+'", "/api"));\n\n')
+rGenCode.append(tabs(indent)+'.process(new OpenApi4jValidator("'+fileName+'", contextPath));\n\n')
 
 //  Add start of rest endpoints.
 indent = 2


### PR DESCRIPTION
Changes based on discussion with Jose to solve the issue of the base path needing to be changed by the developer for the validator in _RoutesGenerated_ after it's changed in the property file.