### PR TITLE
Add check for content before looping over, bump version

### DIFF
--- a/camel-scheduled-archetype/pom.xml
+++ b/camel-scheduled-archetype/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.ms3-inc.camel</groupId>
 	<artifactId>scheduled-archetype</artifactId>
-	<version>0.2.1-SNAPSHOT</version>
+	<version>0.2.2-SNAPSHOT</version>
 	<packaging>maven-archetype</packaging>
 
 	<name>Archetype - camel scheduled archetype</name>

--- a/openapi-archetype/pom.xml
+++ b/openapi-archetype/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.ms3-inc.camel</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openapi-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/openapi-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -154,7 +154,10 @@ for (String path : pathKeys) {
 
 		List<String> produces = new ArrayList<>()
 		getOp.getResponses().forEach{status, resp ->
-				resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}}
+			if (resp.getContent() != null) {
+				resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}
+			}
+		}
 		if (produces.size() > 0) {
 			rGenCode.append(tabs(indent)+'.produces("' + String.join(",", produces) + '")\n')
 		}
@@ -179,7 +182,10 @@ for (String path : pathKeys) {
 
 		List<String> produces = new ArrayList<>()
 		putOp.getResponses().forEach{status, resp ->
-			resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}}
+			if (resp.getContent() != null) {
+				resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}
+			}
+		}
 		if (produces.size() > 0) {
 			rGenCode.append(tabs(indent)+'.produces("' + String.join(",", produces) + '")\n')
 		}
@@ -204,7 +210,10 @@ for (String path : pathKeys) {
 
 		List<String> produces = new ArrayList<>()
 		postOp.getResponses().forEach{status, resp ->
-			resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}}
+			if (resp.getContent() != null) {
+				resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}
+			}
+		}
 		if (produces.size() > 0) {
 			rGenCode.append(tabs(indent)+'.produces("' + String.join(",", produces) + '")\n')
 		}
@@ -223,7 +232,10 @@ for (String path : pathKeys) {
 
 		List<String> produces = new ArrayList<>()
 		deleteOp.getResponses().forEach{status, resp ->
-			resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}}
+			if (resp.getContent() != null) {
+				resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}
+			}
+		}
 		if (produces.size() > 0) {
 			rGenCode.append(tabs(indent)+'.produces("' + String.join(",", produces) + '")\n')
 		}
@@ -248,7 +260,10 @@ for (String path : pathKeys) {
 
 		List<String> produces = new ArrayList<>()
 		patchOp.getResponses().forEach{status, resp ->
-			resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}}
+			if (resp.getContent() != null) {
+				resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}
+			}
+		}
 		if (produces.size() > 0) {
 			rGenCode.append(tabs(indent)+'.produces("' + String.join(",", produces) + '")\n')
 		}
@@ -278,7 +293,10 @@ for (String path : pathKeys) {
 
 		List<String> produces = new ArrayList<>()
 		getOp.getResponses().forEach{status, resp ->
-			resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}}
+			if (resp.getContent() != null) {
+				resp.getContent().forEach{mediaType, mediaTypeObj -> produces.add(mediaType)}
+			}
+		}
 		if (produces.size() > 0) {
 			rGenCode.append(tabs(indent)+'.produces("' + String.join(",", produces) + '")\n')
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ms3-inc.camel</groupId>
     <artifactId>archetypes</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <inceptionYear>2020</inceptionYear>
 


### PR DESCRIPTION
An error in the project generation was occurring when responses didn't have a content attached, which they won't if they are 204, for example. I've added a check to each before they're looped over. Also bumped the version.