### PR TITLE
Version updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Override/recreate settings.xml
         uses: whelk-io/maven-settings-xml-action@v22
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,14 @@ jobs:
         with:
           # needed for license-plugin to check last modified date of each file
           fetch-depth: 0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: '21'
+      - name: Override/recreate settings.xml
+        uses: whelk-io/maven-settings-xml-action@v22
+        with:
+          servers: '[{ "id": "github-arch-snapshots", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}" },{ "id": "github-plugins", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}" }]'
+          plugin_repositories: '[{ "id": "github-plugins", "url": "https://maven.pkg.github.com/ms3inc/camel-restdsl-openapi-plugin" }]'
       - name: mvn clean verify
         run: ./mvnw -V --no-transfer-progress --batch-mode clean verify
   deploy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: '21'
+          distribution: 'adopt'
       - name: Override/recreate settings.xml
         uses: whelk-io/maven-settings-xml-action@v22
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,10 @@ jobs:
           servers: '[{ "id": "github-arch-snapshots", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}" },{ "id": "github-plugins", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}" }]'
           plugin_repositories: '[{ "id": "github-plugins", "url": "https://maven.pkg.github.com/ms3inc/camel-restdsl-openapi-plugin" }]'
       - name: mvn clean verify
-        run: ./mvnw -V --no-transfer-progress --batch-mode clean verify
+        env:
+          GH_USERNAME: "${{ github.actor }}"
+          GH_PAT: "${{ secrets.GITHUB_TOKEN }}"
+        run: ./mvnw -V -X --batch-mode clean verify
   deploy:
     if: github.ref == 'refs/heads/main'
     needs: [ build ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         env:
           GH_USERNAME: "${{ github.actor }}"
           GH_PAT: "${{ secrets.GITHUB_TOKEN }}"
-        run: ./mvnw -V -X --batch-mode clean verify
+        run: ./mvnw -V --no-transfer-progress --batch-mode clean verify
   deploy:
     if: github.ref == 'refs/heads/main'
     needs: [ build ]

--- a/.github/workflows/github-publish.yaml
+++ b/.github/workflows/github-publish.yaml
@@ -1,0 +1,25 @@
+name: Publish package to GitHub Packages
+on:
+  release:
+    types: [published]
+
+env:
+  USERNAME: "${{ github.actor }}"
+  PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Publish package
+        run: mvn --batch-mode deploy

--- a/.github/workflows/github-publish.yaml
+++ b/.github/workflows/github-publish.yaml
@@ -3,10 +3,6 @@ on:
   release:
     types: [published]
 
-env:
-  USERNAME: "${{ github.actor }}"
-  PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -21,5 +17,20 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+      - name: Start OTEL collector
+        run: |
+          docker run -d -p 127.0.0.1:4317:4317 --name collector otel/opentelemetry-collector:0.98.0
+      - name: Override/recreate settings.xml
+        uses: whelk-io/maven-settings-xml-action@v22
+        with:
+          servers: '[{ "id": "github-arch-snapshots", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}" },{ "id": "github-plugins", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}" }]'
+          plugin_repositories: '[{ "id": "github-plugins", "url": "https://maven.pkg.github.com/ms3inc/camel-restdsl-openapi-plugin" }]'
       - name: Publish package
+        env:
+          GH_USERNAME: "${{ github.actor }}"
+          GH_PAT: "${{ secrets.GITHUB_TOKEN }}"
         run: mvn --batch-mode deploy
+      - name: Stop OTEL collector
+        run: |
+          docker stop collector
+          docker rm collector

--- a/.settings.xml
+++ b/.settings.xml
@@ -19,11 +19,6 @@
                       http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
         <server>
-            <id>github-arch-snapshots</id>
-            <username>${env.USERNAME}</username>
-            <password>${env.PASSWORD}</password>
-        </server>
-        <server>
             <id>sonatype-ossrh</id>
             <username>${env.SONATYPE_USER}</username>
             <password>${env.SONATYPE_PASSWORD}</password>

--- a/.settings.xml
+++ b/.settings.xml
@@ -19,9 +19,9 @@
                       http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
         <server>
-            <id>ms3-nexus</id>
-            <username>${env.REPO_USER}</username>
-            <password>${env.REPO_PASSWORD}</password>
+            <id>github-arch-snapshots</id>
+            <username>${env.USERNAME}</username>
+            <password>${env.PASSWORD}</password>
         </server>
         <server>
             <id>sonatype-ossrh</id>

--- a/.settings.xml
+++ b/.settings.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2020-2021 the original author or authors.
+    Copyright 2020-2024 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -24,9 +24,9 @@ There is currently no way to update an API that has already been created with th
 
 (Temporary instructions related to recent changes, this section should be reverted or changed before merge)
 
-This version of the archetypes has only been released as a snapshot on Github. The camel-restdsl-openapi-plugin and camel-rest-extensions have also been released on GitHub to support this. Follow the below instructions to get set up.
+This version of the archetypes (0.2.8-SNAPSHOT) has only been released as a snapshot on Github. The camel-restdsl-openapi-plugin and camel-rest-extensions have also been released on GitHub to support this. Follow the below instructions to get set up.
 
-1. If you have previously installed the archetype, camel-rest-extensions, camel-restdsl-openapi-plugin locally, delete them from your .m2 repo.
+1. If you have previously installed the archetype, camel-rest-extensions, camel-restdsl-openapi-plugin locally, delete them from your .m2 repo inside of the com.ms3-inc.tavros folder.
 2. Create or login to an existing GitHub account.
 3. Create [a classic Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with ONLY `read:packages` scope necessary
 4. Modify your settings.xml with the values below, and replace the username and password fields with your GitHub credentials.
@@ -83,6 +83,8 @@ This version of the archetypes has only been released as a snapshot on Github. T
     <activeProfile>github</activeProfile>
   </activeProfiles>
 ```
+
+Once those steps are complete, you can move on to the next step of running the archetype.
 
 ### How do I run the archetype? ###
 

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -77,31 +77,36 @@ docker run -p 9000:9000 -p 8080:8080 -it <tag>
 
 ### Manual Acceptance Tests of generated archetype ###
 
-#### Confirm ready - PASSING
+To test:
+- generate a project without a specificationUri to use the provided OAS
+- generate a project with a downloaded [Pet Store spec](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+
+#### Tests for default OAS: ####
+**Confirm ready - PASSING**  
 curl 'http://localhost:8080/actuator/health/readiness'
 
-#### Confirm GET works - PASSING
+**Confirm GET works - PASSING**  
 curl 'http://localhost:9000/api/hello'
 
-#### Confirm POST works - PASSING
+**Confirm POST works - PASSING**  
 curl --location --request POST 'http://localhost:9000/api/greeting' \
 --header 'Content-Type: application/json' \
 --data-raw '{
 "caller":"other"
 }'
 
-#### Confirm main exception handling works - PASSING
+**Confirm main exception handling works - PASSING**  
 example: .throwException(new ArithmeticException())
 
-#### Confirm RestException returns correctly - PASSING
+**Confirm RestException returns correctly - PASSING**  
 curl --location --request POST 'http://localhost:9000/api/greeting' \
 --header 'Content-Type: application/json' \
 --data-raw '{
 "wrongProp":"other"
 }'
 
-#### Confirm logs contain unique span and trace ids - FAILING
-#### Confirm traces can be seen in Jaeger - FAILING
+**Confirm logs contain unique span and trace ids - FAILING**  
+**Confirm traces can be seen in Jaeger - FAILING**  
 
 ### Who do I talk to? ###
 

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -14,7 +14,7 @@ Primary changes:
 - Dockerfile updated to use Java 21
 - A number of other dependency changes in the pom to support the above changes
 - `datasonnet()` now replaces usages of `datasonnetEx()` or `DatasonnetExpression.builder()`. Examples are in BaseRestRouteBuilder and RoutesImplementation.
-- Spans/tracing currently not functioning
+- Spans/tracing fixed but only locally tested thus far
 
 ### Migration recommendations ###
 
@@ -105,8 +105,8 @@ curl --location --request POST 'http://localhost:9000/api/greeting' \
 "wrongProp":"other"
 }'
 
-**Confirm logs contain unique span and trace ids - FAILING**  
-**Confirm traces can be seen in Jaeger - FAILING**  
+**Confirm logs contain unique span and trace ids - PASSING**  
+**Confirm traces can be seen in Jaeger, and GET /hello shows as 4 spans - PASSING**  
 
 ### Who do I talk to? ###
 

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -47,7 +47,7 @@ To generate an API using the archetype you just installed locally, cd to your AP
 This version also uses a snapshot version of camel-rest-extensions which is not yet in maven central. [Refer to the release for more info as to why it was added](https://github.com/MS3Inc/camel-rest-extensions/releases/tag/0.1.7-SNAPSHOT)
 
 To use this version:
-- A Github account is required along with [a classic Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
+- A Github account is required along with [a classic Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with ONLY `read:packages` scope necessary
 - A server configuration in your settings.xml, similar to this:
 ```
 <servers>

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -3,29 +3,13 @@
 This is a Maven archetype that generates a Camel/SpringBoot application with stubs for API endpoints generated from a provided OpenAPI document.
 It is part of MS3's integration platform, [Tavros](https://github.com/MS3Inc/tavros).
 
-### Pre-release notes ###
-
-(Notes related to recent changes, this section can be removed before merge)
-
-Tested changes:
-- Update to SB 3.3.0 (LTS)
-- Update to Camel 4.4.3 (LTS to fix [memory issue that causes DS expressions to stop working until restart](https://issues.apache.org/jira/browse/CAMEL-20841))
-- Dockerfile updated to use Java 21
-- A number of other dependency changes in the pom to support the above changes
-- `datasonnet()` now replaces usages of `datasonnetEx()` or `DatasonnetExpression.builder()`. Examples are in BaseRestRouteBuilder and RoutesImplementation.
-
-Untested Tavros changes:
-- Spans/tracing fixed, only locally tested
-
 ### Migration recommendations ###
 
 There is currently no way to update an API that has already been created with the archetype. The recommended way to update existing applications is to regenerate the API using the same specification in a different folder and then use a diff tool such as Beyond Compare to migrate changes. It will likely be easier to move the newly generated code to the previously generated code but it largely depends on what the diff is.
 
 ### How do I get set up? ###
 
-(Possible temporary instructions related to recent changes, this section should be reverted or changed before merge)
-
-This version of the archetypes has only been released as a snapshot on Github. The camel-restdsl-openapi-plugin and camel-rest-extensions have also been released on GitHub to support this. Follow the below instructions to get set up.
+This version of the archetypes is currently being released as a snapshot on Github. The camel-restdsl-openapi-plugin and camel-rest-extensions have also been released on GitHub to support this. Follow the below instructions to get set up.
 
 1. If you have previously installed the archetype, camel-rest-extensions, camel-restdsl-openapi-plugin locally, delete them from your .m2 repo inside of the com.ms3-inc.tavros folder.
 2. Create or login to an existing GitHub account.
@@ -95,7 +79,7 @@ To run the archetype, `cd` to the directory where the new project will live and 
 mvn archetype:generate \
 -DarchetypeGroupId=com.ms3-inc.tavros \
 -DarchetypeArtifactId=camel-openapi-archetype \
--DarchetypeVersion=0.2.9-SNAPSHOT \
+-DarchetypeVersion=<check-for-latest> \
 -DgroupId=<groupId> \
 -Dversion=0.1.0-SNAPSHOT \
 -DartifactId=<project-name> \
@@ -119,38 +103,13 @@ docker build -t <tag> .
 docker run -p 9000:9000 -p 8080:8080 -it <tag>
 ```
 
-### Manual Acceptance Tests of generated archetype ###
+### To allow the OTEL logging
 
-To test:
-- generate a project without a specificationUri to use the provided OAS
-- generate a project with a downloaded [Pet Store spec](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+The `maven-dependency-plugin` config is what moves the OTEL agent to the target folder.
 
-#### Tests for default OAS: ####
-**Confirm ready - PASSING**  
-curl 'http://localhost:8080/actuator/health/readiness'
+The `configuration.agents.agent` in the `spring-boot-maven-plugin` is what allows `mvn spring-boot:run` to start with the OTEL agent.
 
-**Confirm GET works - PASSING**  
-curl 'http://localhost:9000/api/hello'
-
-**Confirm POST works - PASSING**  
-curl --location --request POST 'http://localhost:9000/api/greeting' \
---header 'Content-Type: application/json' \
---data-raw '{
-"caller":"other"
-}'
-
-**Confirm main exception handling works - PASSING**  
-example: .throwException(new ArithmeticException())
-
-**Confirm RestException returns correctly - PASSING**  
-curl --location --request POST 'http://localhost:9000/api/greeting' \
---header 'Content-Type: application/json' \
---data-raw '{
-"wrongProp":"other"
-}'
-
-**Confirm logs contain unique span and trace ids inside of the MDC - FAILING**  
-**Confirm traces can be seen in Jaeger, and GET /hello shows as 4 spans - PASSING**
+In JVM arguments in your IDE or deploed, configure `-javaagent:target/javaagents/javaagent.jar` allow the agent to start along with SB.
 
 ### Who do I talk to? ###
 

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -5,11 +5,23 @@ It is part of MS3's integration platform, [Tavros](https://github.com/MS3Inc/tav
 
 ### How do I get set up? ###
 
-Clone the main branch of this repo. 
+Temporary instructions:
+This version of the archetypes is not released and needs to be installed locally.
+Clone both the camel-restdsl-openapi-plugin (branch: arch-version-updates) and camel-archetypes (branch: version-updates) repos and install them locally.
 
-To build the archetype, `cd` into the archetype source and run `mvn clean install`.
+Linux/bash instructions:
+```
+mkdir arch-0-28-SNAPSHOT
+cd arch-0-28-SNAPSHOT
+git clone -b arch-version-updates https://github.com/MS3Inc/camel-restdsl-openapi-plugin.git
+git clone -b version-updates https://github.com/MS3Inc/camel-archetypes.git
+cd camel-restdsl-openapi-plugin
+mvn clean install
+cd ../camel-archetypes
+mvn clean install
+```
 
-If changes are made to the [OpenAPI plugin](https://github.com/MS3Inc/camel-restdsl-openapi-plugin), the version should be changed in `archetype-post-generate.groovy` by changing the `camelRestDslPluginVersion` variable.
+To generate an API using the archetype you just installed locally, cd to your API directory and run the command below with version `-DarchetypeVersion=0.2.8-SNAPSHOT`.
 
 ### How do I run the archetype? ###
 
@@ -33,6 +45,14 @@ The `-DpackageInPathFormat` and `-package` arguments should be supplied if your 
 -DpackageInPathFormat \
 -Dpackage=com.ms3_inc.tavros \
 -DgroupId=com.ms3-inc.tavros \
+```
+
+### To use the Dockerfile locally
+
+```
+mvn clean package
+docker build -t <tag> .
+docker run -p 9000:9000 -p 8080:8080 -it <tag>
 ```
 
 ### Who do I talk to? ###

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -43,6 +43,22 @@ mvn clean install
 
 To generate an API using the archetype you just installed locally, cd to your API directory and run the command below with version `-DarchetypeVersion=0.2.8-SNAPSHOT`.
 
+#### Pulling camel-rest-extensions ####
+This version also uses a snapshot version of camel-rest-extensions which is not yet in maven central. [Refer to the release for more info as to why it was added](https://github.com/MS3Inc/camel-rest-extensions/releases/tag/0.1.7-SNAPSHOT)
+
+To use this version:
+- A Github account is required along with [a classic Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
+- A server configuration in your settings.xml, similar to this:
+```
+<servers>
+    <server>
+        <id>github-pull</id>
+        <username>your github username</username>
+        <password>your PAT created above</password>
+    </server>
+</servers>
+```
+
 ### How do I run the archetype? ###
 
 To run the archetype, `cd` to the directory where the new project will live and then run:

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -27,6 +27,8 @@ There is currently no way to update an API that has already been created with th
 This version of the archetypes is not released and needs to be installed locally.
 Clone both the camel-restdsl-openapi-plugin (branch: arch-version-updates) and camel-archetypes (branch: version-updates) repos and install them locally.
 
+Refer to the below instructions for creating a GitHub PAT before proceeding. Copy your username and password from the server block in your settings.xml and replace it on lines 25 and 26 in `/camel-archetypes/camel-openapi-archetype/src/test/resources/settings.xml`
+
 Linux/bash instructions:
 ```
 mkdir arch-0-28-SNAPSHOT
@@ -37,22 +39,22 @@ cd camel-restdsl-openapi-plugin
 git checkout 21c33cc834ae91c362bdb722d14f8c1a6918f075
 mvn clean install
 cd ../camel-archetypes
-git checkout a1fe31391f31804ea0d5a952ff5059169968ddcc
+git checkout version-updates
 mvn clean install
 ```
 
 To generate an API using the archetype you just installed locally, cd to your API directory and run the command below with version `-DarchetypeVersion=0.2.8-SNAPSHOT`.
 
-#### Pulling camel-rest-extensions ####
+#### Pulling camel-rest-extensions in your API project ####
 This version also uses a snapshot version of camel-rest-extensions which is not yet in maven central. [Refer to the release for more info as to why it was added](https://github.com/MS3Inc/camel-rest-extensions/releases/tag/0.1.7-SNAPSHOT)
 
 To use this version:
-- A Github account is required along with [a classic Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with ONLY `read:packages` scope necessary
+- A GitHub account is required along with [a classic Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with ONLY `read:packages` scope necessary
 - A server configuration in your settings.xml, similar to this:
 ```
 <servers>
     <server>
-        <id>github-pull</id>
+        <id>github-snapshots</id>
         <username>your github username</username>
         <password>your PAT created above</password>
     </server>

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -13,11 +13,13 @@ Linux/bash instructions:
 ```
 mkdir arch-0-28-SNAPSHOT
 cd arch-0-28-SNAPSHOT
-git clone -b arch-version-updates https://github.com/MS3Inc/camel-restdsl-openapi-plugin.git
-git clone -b version-updates https://github.com/MS3Inc/camel-archetypes.git
+git clone https://github.com/MS3Inc/camel-restdsl-openapi-plugin.git
+git clone https://github.com/MS3Inc/camel-archetypes.git
 cd camel-restdsl-openapi-plugin
+git checkout 21c33cc834ae91c362bdb722d14f8c1a6918f075
 mvn clean install
 cd ../camel-archetypes
+git checkout 56ded315199b081905c141e26674a5678f889c9c
 mvn clean install
 ```
 

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -71,9 +71,18 @@ This version of the archetypes is currently being released as a snapshot on Gith
 
 Once those steps are complete, you can move on to the next step of running the archetype.
 
-### How do I run the archetype? ###
+## Development
 
-To run the archetype, `cd` to the directory where the new project will live and then run:
+- Clone the main branch of this repo.
+- To build the archetype, `cd` into the archetype source and run `mvn clean install`.
+
+### How do I use the archetype? ###
+
+It's not necessary to install the archetype unless you are making changes to it.
+
+To view latest snapshot releases view [GitHub releases](https://github.com/MS3Inc/camel-archetypes/releases)
+
+To generate a project based on the archetype, `cd` to the directory where the new project will live and then run:
 
 ```bash
 mvn archetype:generate \

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -12,9 +12,13 @@ Primary changes:
 - Update to Camel 4.5.0
 - Update DS mapper to 2.5.2-jakarta4
 - Dockerfile updated to use Java 21
-- A number of other dependency changes to support the above changes
+- A number of other dependency changes in the pom to support the above changes
 - `datasonnet()` now replaces usages of `datasonnetEx()` or `DatasonnetExpression.builder()`. Examples are in BaseRestRouteBuilder and RoutesImplementation.
 - Spans/tracing currently not functioning
+
+### Migration recommendations ###
+
+There is currently no way to update an API that has already been created with the archetype. The recommended way to update existing applications is to regenerate the API using the same specification in a different folder and then use a diff tool such as Beyond Compare to migrate changes. It will likely be easier to move the newly generated code to the previously generated code but it largely depends on what the diff is.
 
 ### How do I get set up? ###
 

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -74,6 +74,7 @@ Once those steps are complete, you can move on to the next step of running the a
 ## Development
 
 - Clone the main branch of this repo.
+- If changes are made to the [OpenAPI plugin](https://github.com/MS3Inc/camel-restdsl-openapi-plugin), the version should be changed in `archetype-post-generate.groovy` by changing the `camelRestDslPluginVersion` variable.
 - To build the archetype, `cd` into the archetype source and run `mvn clean install`.
 
 ### How do I use the archetype? ###

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -148,7 +148,7 @@ curl --location --request POST 'http://localhost:9000/api/greeting' \
 "wrongProp":"other"
 }'
 
-**Confirm logs contain unique span and trace ids - PASSING**  
+**Confirm logs contain unique span and trace ids inside of the MDC - FAILING**  
 **Confirm traces can be seen in Jaeger, and GET /hello shows as 4 spans - PASSING**
 
 ### Who do I talk to? ###

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -22,43 +22,66 @@ There is currently no way to update an API that has already been created with th
 
 ### How do I get set up? ###
 
-(Temporary instructions related to recent changes, this section can be reverted before merge)
+(Temporary instructions related to recent changes, this section should be reverted or changed before merge)
 
-This version of the archetypes is not released and needs to be installed locally.
-Clone both the camel-restdsl-openapi-plugin (branch: arch-version-updates) and camel-archetypes (branch: version-updates) repos and install them locally.
+This version of the archetypes has only been released as a snapshot on Github. The camel-restdsl-openapi-plugin and camel-rest-extensions have also been released on GitHub to support this. Follow the below instructions to get set up.
 
-Refer to the below instructions for creating a GitHub PAT before proceeding. Copy your username and password from the server block in your settings.xml and replace it on lines 25 and 26 in `/camel-archetypes/camel-openapi-archetype/src/test/resources/settings.xml`
-
-Linux/bash instructions:
+1. If you have previously installed the archetype, camel-rest-extensions, camel-restdsl-openapi-plugin locally, delete them from your .m2 repo.
+2. Create or login to an existing GitHub account.
+3. Create [a classic Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with ONLY `read:packages` scope necessary
+4. Modify your settings.xml with the values below, and replace the username and password fields with your GitHub credentials.
 ```
-mkdir arch-0-28-SNAPSHOT
-cd arch-0-28-SNAPSHOT
-git clone https://github.com/MS3Inc/camel-restdsl-openapi-plugin.git
-git clone https://github.com/MS3Inc/camel-archetypes.git
-cd camel-restdsl-openapi-plugin
-git checkout 21c33cc834ae91c362bdb722d14f8c1a6918f075
-mvn clean install
-cd ../camel-archetypes
-git checkout version-updates
-mvn clean install
-```
-
-To generate an API using the archetype you just installed locally, cd to your API directory and run the command below with version `-DarchetypeVersion=0.2.8-SNAPSHOT`.
-
-#### Pulling camel-rest-extensions in your API project ####
-This version also uses a snapshot version of camel-rest-extensions which is not yet in maven central. [Refer to the release for more info as to why it was added](https://github.com/MS3Inc/camel-rest-extensions/releases/tag/0.1.7-SNAPSHOT)
-
-To use this version:
-- A GitHub account is required along with [a classic Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with ONLY `read:packages` scope necessary
-- A server configuration in your settings.xml, similar to this:
-```
-<servers>
+  <servers>
     <server>
-        <id>github-snapshots</id>
+      <!-- ID matching repo in generated API from archetype -->
+      <id>github-ms3-extensions</id>
         <username>your github username</username>
         <password>your PAT created above</password>
     </server>
-</servers>
+    <server>
+      <id>archetype</id>
+        <username>your github username</username>
+        <password>your PAT created above</password>
+    </server>
+    <server>
+      <id>github-plugins</id>
+        <username>your github username</username>
+        <password>your PAT created above</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>github</id>
+      <repositories>
+        <repository>
+          <id>archetype</id>
+          <url>https://maven.pkg.github.com/ms3inc/camel-archetypes</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+              <enabled>true</enabled>
+          </snapshots>
+      </repository>
+    </repositories>
+    <pluginRepositories>
+      <pluginRepository>
+        <id>github-plugins</id>
+        <snapshots>
+          <enabled>true</enabled>
+        </snapshots>
+        <releases>
+          <enabled>true</enabled>
+        </releases>
+        <url>https://maven.pkg.github.com/ms3inc/camel-restdsl-openapi-plugin</url>
+      </pluginRepository>
+    </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>github</activeProfile>
+  </activeProfiles>
 ```
 
 ### How do I run the archetype? ###
@@ -69,7 +92,7 @@ To run the archetype, `cd` to the directory where the new project will live and 
 mvn archetype:generate \
 -DarchetypeGroupId=com.ms3-inc.tavros \
 -DarchetypeArtifactId=camel-openapi-archetype \
--DarchetypeVersion=<check-for-latest> \
+-DarchetypeVersion=0.2.8-SNAPSHOT \
 -DgroupId=<groupId> \
 -Dversion=0.1.0-SNAPSHOT \
 -DartifactId=<project-name> \
@@ -124,7 +147,7 @@ curl --location --request POST 'http://localhost:9000/api/greeting' \
 }'
 
 **Confirm logs contain unique span and trace ids - PASSING**  
-**Confirm traces can be seen in Jaeger, and GET /hello shows as 4 spans - PASSING**  
+**Confirm traces can be seen in Jaeger, and GET /hello shows as 4 spans - PASSING**
 
 ### Who do I talk to? ###
 

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -7,14 +7,15 @@ It is part of MS3's integration platform, [Tavros](https://github.com/MS3Inc/tav
 
 (Notes related to recent changes, this section can be removed before merge)
 
-Primary changes:
-- Update to SB 3.2.4
-- Update to Camel 4.5.0
-- Update DS mapper to 2.5.2-jakarta4
+Tested changes:
+- Update to SB 3.3.0 (LTS)
+- Update to Camel 4.4.3 (LTS to fix [memory issue that causes DS expressions to stop working until restart](https://issues.apache.org/jira/browse/CAMEL-20841))
 - Dockerfile updated to use Java 21
 - A number of other dependency changes in the pom to support the above changes
 - `datasonnet()` now replaces usages of `datasonnetEx()` or `DatasonnetExpression.builder()`. Examples are in BaseRestRouteBuilder and RoutesImplementation.
-- Spans/tracing fixed but only locally tested thus far
+
+Untested Tavros changes:
+- Spans/tracing fixed, only locally tested
 
 ### Migration recommendations ###
 
@@ -22,9 +23,9 @@ There is currently no way to update an API that has already been created with th
 
 ### How do I get set up? ###
 
-(Temporary instructions related to recent changes, this section should be reverted or changed before merge)
+(Possible temporary instructions related to recent changes, this section should be reverted or changed before merge)
 
-This version of the archetypes (0.2.8-SNAPSHOT) has only been released as a snapshot on Github. The camel-restdsl-openapi-plugin and camel-rest-extensions have also been released on GitHub to support this. Follow the below instructions to get set up.
+This version of the archetypes has only been released as a snapshot on Github. The camel-restdsl-openapi-plugin and camel-rest-extensions have also been released on GitHub to support this. Follow the below instructions to get set up.
 
 1. If you have previously installed the archetype, camel-rest-extensions, camel-restdsl-openapi-plugin locally, delete them from your .m2 repo inside of the com.ms3-inc.tavros folder.
 2. Create or login to an existing GitHub account.
@@ -94,7 +95,7 @@ To run the archetype, `cd` to the directory where the new project will live and 
 mvn archetype:generate \
 -DarchetypeGroupId=com.ms3-inc.tavros \
 -DarchetypeArtifactId=camel-openapi-archetype \
--DarchetypeVersion=0.2.8-SNAPSHOT \
+-DarchetypeVersion=0.2.9-SNAPSHOT \
 -DgroupId=<groupId> \
 -Dversion=0.1.0-SNAPSHOT \
 -DartifactId=<project-name> \

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -55,6 +55,34 @@ docker build -t <tag> .
 docker run -p 9000:9000 -p 8080:8080 -it <tag>
 ```
 
+### Manual Acceptance Tests of generated archetype ###
+
+#### Confirm ready - PASSING
+curl 'http://localhost:8080/actuator/health/readiness'
+
+#### Confirm GET works - PASSING
+curl 'http://localhost:9000/api/hello'
+
+#### Confirm POST works - PASSING
+curl --location --request POST 'http://localhost:9000/api/greeting' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+"caller":"other"
+}'
+
+#### Confirm main exception handling works - PASSING
+example: .throwException(new ArithmeticException())
+
+#### Confirm RestException returns correctly - PASSING
+curl --location --request POST 'http://localhost:9000/api/greeting' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+"wrongProp":"other"
+}'
+
+#### Confirm logs contain unique span and trace ids - FAILING
+#### Confirm traces can be seen in Jaeger - FAILING
+
 ### Who do I talk to? ###
 
 Contact:

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -37,7 +37,7 @@ cd camel-restdsl-openapi-plugin
 git checkout 21c33cc834ae91c362bdb722d14f8c1a6918f075
 mvn clean install
 cd ../camel-archetypes
-git checkout 56ded315199b081905c141e26674a5678f889c9c
+git checkout da5053a7e79d0774a107caf9080f20b4308d4fee
 mvn clean install
 ```
 

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -37,7 +37,7 @@ cd camel-restdsl-openapi-plugin
 git checkout 21c33cc834ae91c362bdb722d14f8c1a6918f075
 mvn clean install
 cd ../camel-archetypes
-git checkout da5053a7e79d0774a107caf9080f20b4308d4fee
+git checkout a1fe31391f31804ea0d5a952ff5059169968ddcc
 mvn clean install
 ```
 

--- a/camel-openapi-archetype/README.md
+++ b/camel-openapi-archetype/README.md
@@ -3,9 +3,23 @@
 This is a Maven archetype that generates a Camel/SpringBoot application with stubs for API endpoints generated from a provided OpenAPI document.
 It is part of MS3's integration platform, [Tavros](https://github.com/MS3Inc/tavros).
 
+### Pre-release notes ###
+
+(Notes related to recent changes, this section can be removed before merge)
+
+Primary changes:
+- Update to SB 3.2.4
+- Update to Camel 4.5.0
+- Update DS mapper to 2.5.2-jakarta4
+- Dockerfile updated to use Java 21
+- A number of other dependency changes to support the above changes
+- `datasonnet()` now replaces usages of `datasonnetEx()` or `DatasonnetExpression.builder()`. Examples are in BaseRestRouteBuilder and RoutesImplementation.
+- Spans/tracing currently not functioning
+
 ### How do I get set up? ###
 
-Temporary instructions:
+(Temporary instructions related to recent changes, this section can be reverted before merge)
+
 This version of the archetypes is not released and needs to be installed locally.
 Clone both the camel-restdsl-openapi-plugin (branch: arch-version-updates) and camel-archetypes (branch: version-updates) repos and install them locally.
 

--- a/camel-openapi-archetype/pom.xml
+++ b/camel-openapi-archetype/pom.xml
@@ -64,14 +64,12 @@
 
 	<distributionManagement>
 		<repository>
-			<id>ms3-nexus</id>
-			<name>maven-releases</name>
-			<url>https://maven.ms3-inc.com/repository/maven-releases/</url>
+			<id>github-arch-snapshots</id>
+			<url>https://maven.pkg.github.com/ms3inc/camel-archetypes</url>
 		</repository>
 		<snapshotRepository>
-			<id>ms3-nexus</id>
-			<name>maven-snapshots</name>
-			<url>https://maven.ms3-inc.com/repository/maven-snapshots/</url>
+			<id>github-arch-snapshots</id>
+			<url>https://maven.pkg.github.com/ms3inc/camel-archetypes</url>
 		</snapshotRepository>
 	</distributionManagement>
 

--- a/camel-openapi-archetype/pom.xml
+++ b/camel-openapi-archetype/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2020-2021 the original author or authors.
+    Copyright 2020-2024 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/camel-openapi-archetype/pom.xml
+++ b/camel-openapi-archetype/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.ms3-inc.tavros</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.2.8-SNAPSHOT</version>
+        <version>0.2.9-SNAPSHOT</version>
     </parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/camel-openapi-archetype/src/main/archetype/Dockerfile
+++ b/camel-openapi-archetype/src/main/archetype/Dockerfile
@@ -1,13 +1,13 @@
-FROM adoptopenjdk/openjdk11:alpine-jre as builder
+FROM eclipse-temurin:21-jre-alpine as builder
 WORKDIR application
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR application
 COPY --from=builder application/dependencies/ ./
 COPY --from=builder application/spring-boot-loader/ ./
 COPY --from=builder application/snapshot-dependencies/ ./
 COPY --from=builder application/application/ ./
-ENTRYPOINT ["java", "-XX:MinRAMPercentage=50.0", "-XX:MaxRAMPercentage=90.0", "org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java", "-XX:MinRAMPercentage=50.0", "-XX:MaxRAMPercentage=90.0", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/camel-openapi-archetype/src/main/archetype/pom.xml
+++ b/camel-openapi-archetype/src/main/archetype/pom.xml
@@ -18,6 +18,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <spring-boot.version>3.2.4</spring-boot.version>
         <camel.version>4.5.0</camel.version>
+        <opentelemetry-agent.version>1.25.1</opentelemetry-agent.version>
     </properties>
 
     <dependencyManagement>
@@ -131,6 +132,11 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-opentelemetry-starter</artifactId>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -189,12 +195,43 @@
                     <layers>
                         <enabled>true</enabled>
                     </layers>
+                    <agents>
+                        <agent>${project.build.directory}/javaagents/javaagent.jar</agent>
+                    </agents>
+                    <environmentVariables>
+                        <OTEL_SERVICE_NAME>${project.artifactId}</OTEL_SERVICE_NAME>
+                    </environmentVariables>
                 </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>repackage</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-javaagent</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry-agent.version}</version>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/javaagents</outputDirectory>
+                                    <destFileName>javaagent.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/camel-openapi-archetype/src/main/archetype/pom.xml
+++ b/camel-openapi-archetype/src/main/archetype/pom.xml
@@ -23,7 +23,7 @@
 
     <repositories>
         <repository>
-            <id>github-pull</id>
+            <id>github-snapshots</id>
             <url>https://maven.pkg.github.com/ms3inc/camel-rest-extensions</url>
             <snapshots>
                 <enabled>true</enabled>

--- a/camel-openapi-archetype/src/main/archetype/pom.xml
+++ b/camel-openapi-archetype/src/main/archetype/pom.xml
@@ -14,8 +14,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <spring-boot.version>3.2.4</spring-boot.version>
         <camel.version>4.5.0</camel.version>
         <opentelemetry-agent.version>1.25.1</opentelemetry-agent.version>

--- a/camel-openapi-archetype/src/main/archetype/pom.xml
+++ b/camel-openapi-archetype/src/main/archetype/pom.xml
@@ -23,7 +23,7 @@
 
     <repositories>
         <repository>
-            <id>github-snapshots</id>
+            <id>github-ms3-extensions</id>
             <url>https://maven.pkg.github.com/ms3inc/camel-rest-extensions</url>
             <snapshots>
                 <enabled>true</enabled>

--- a/camel-openapi-archetype/src/main/archetype/pom.xml
+++ b/camel-openapi-archetype/src/main/archetype/pom.xml
@@ -21,6 +21,16 @@
         <opentelemetry-agent.version>1.25.1</opentelemetry-agent.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>github-pull</id>
+            <url>https://maven.pkg.github.com/ms3inc/camel-rest-extensions</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <!-- Override Log4j2, related to https://github.com/spring-projects/spring-boot/issues/33450 -->
@@ -122,7 +132,7 @@
         <dependency>
             <groupId>com.ms3-inc.tavros</groupId>
             <artifactId>camel-rest-extensions</artifactId>
-            <version>0.1.6</version>
+            <version>0.1.7-SNAPSHOT</version>
             <exclusions>
                 <!-- https://github.com/spring-projects/spring-framework/issues/20611 -->
                 <exclusion>

--- a/camel-openapi-archetype/src/main/archetype/pom.xml
+++ b/camel-openapi-archetype/src/main/archetype/pom.xml
@@ -16,17 +16,17 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <spring-boot.version>2.3.2.RELEASE</spring-boot.version>
-        <camel.version>3.7.1</camel.version>
+        <spring-boot.version>3.2.4</spring-boot.version>
+        <camel.version>4.5.0</camel.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!-- override log4j, related to CVE-2021-45105, CVE-2021-45046 and CVE-2021-44228 -->
+            <!-- Override Log4j2, related to https://github.com/spring-projects/spring-boot/issues/33450 -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
-                <version>2.17.0</version>
+                <version>3.0.0-beta1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -45,18 +45,6 @@
                 <version>${camel.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <!-- override camel's scala version -->
-            <dependency>
-                <groupId>org.scala-lang</groupId>
-                <artifactId>scala-library</artifactId>
-                <version>2.13.3</version>
-            </dependency>
-            <!-- override camel's datasonnet -->
-            <dependency>
-                <groupId>com.datasonnet</groupId>
-                <artifactId>datasonnet-mapper</artifactId>
-                <version>2.1.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -134,28 +122,12 @@
             <groupId>com.ms3-inc.tavros</groupId>
             <artifactId>camel-rest-extensions</artifactId>
             <version>0.1.6</version>
-        </dependency>
-
-        <!-- OpenTracing deps -->
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-opentracing-starter</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.camel</groupId>
-                    <artifactId>camel-opentracing</artifactId>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.ms3-inc.tavros</groupId>
-            <artifactId>camel-opentracing</artifactId>
-            <version>${camel.version}-002</version>
-        </dependency>
-        <dependency>
-            <groupId>io.jaegertracing</groupId>
-            <artifactId>jaeger-client</artifactId>
-            <version>1.5.0</version>
         </dependency>
 
         <!-- Test -->

--- a/camel-openapi-archetype/src/main/archetype/pom.xml
+++ b/camel-openapi-archetype/src/main/archetype/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
-            <version>3.4.2</version>
+            <version>4.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/camel-openapi-archetype/src/main/archetype/pom.xml
+++ b/camel-openapi-archetype/src/main/archetype/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring-boot.version>3.2.4</spring-boot.version>
-        <camel.version>4.5.0</camel.version>
+        <spring-boot.version>3.3.0</spring-boot.version>
+        <camel.version>4.4.3</camel.version>
         <opentelemetry-agent.version>1.25.1</opentelemetry-agent.version>
     </properties>
 

--- a/camel-openapi-archetype/src/main/archetype/pom.xml
+++ b/camel-openapi-archetype/src/main/archetype/pom.xml
@@ -123,6 +123,7 @@
             <artifactId>camel-rest-extensions</artifactId>
             <version>0.1.6</version>
             <exclusions>
+                <!-- https://github.com/spring-projects/spring-framework/issues/20611 -->
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>

--- a/camel-openapi-archetype/src/main/archetype/src/generated/java/RoutesGenerated.java
+++ b/camel-openapi-archetype/src/main/archetype/src/generated/java/RoutesGenerated.java
@@ -1,7 +1,5 @@
 package ${package};
 
-import javax.annotation.Generated;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import com.ms3_inc.tavros.extensions.rest.OpenApi4jValidator;
@@ -11,7 +9,6 @@ import com.ms3_inc.tavros.extensions.rest.OpenApi4jValidator;
  *
  * @author Maven Archetype (camel-oas-archetype)
  */
-@Generated("com.ms3_inc.camel.archetype.oas")
 @Component
 public class RoutesGenerated extends BaseRestRouteBuilder {
     private final String contextPath;

--- a/camel-openapi-archetype/src/main/archetype/src/main/java/BaseRestRouteBuilder.java
+++ b/camel-openapi-archetype/src/main/archetype/src/main/java/BaseRestRouteBuilder.java
@@ -3,7 +3,6 @@ package ${package};
 import com.datasonnet.document.DefaultDocument;
 import com.datasonnet.document.Document;
 import com.datasonnet.document.MediaTypes;
-import org.apache.camel.language.datasonnet.DatasonnetExpression;
 import com.ms3_inc.tavros.extensions.rest.OperationResult;
 import com.ms3_inc.tavros.extensions.rest.exception.RestException;
 import org.apache.camel.Exchange;
@@ -22,16 +21,6 @@ import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
  * @author Maven Archetype (camel-oas-archetype)
  */
 public class BaseRestRouteBuilder extends EndpointRouteBuilder {
-    protected DatasonnetExpression datasonnetEx(String expression) {
-        return (DatasonnetExpression) getContext().resolveLanguage("datasonnet").createExpression(expression);
-    }
-
-    protected DatasonnetExpression datasonnetEx(String expression, Class<?> resultType) {
-        Object[] properties = new Object[3];
-        properties[0] = resultType;
-        return (DatasonnetExpression) getContext().resolveLanguage("datasonnet").createExpression(expression, properties);
-    }
-
     private static final Processor REST_EXCEPTION_PROCESSOR = ex -> {
         RestException exc = ex.getProperty(Exchange.EXCEPTION_CAUGHT, RestException.class);
 
@@ -61,8 +50,12 @@ public class BaseRestRouteBuilder extends EndpointRouteBuilder {
             .logStackTrace(true)
             .process(REST_EXCEPTION_PROCESSOR)
             .setBody(constant(DefaultDocument.NULL_INSTANCE))
-            .transform(datasonnetEx("resource:classpath:rest-exception.ds", String.class)
-                    .outputMediaType(MediaTypes.APPLICATION_JSON))
+            .transform(datasonnet("resource:classpath:rest-exception.ds",
+                       String.class,
+                       MediaTypes.ANY.toString(),
+                       MediaTypes.APPLICATION_JSON.toString()
+                      )
+            )
         ;
 
         onException(Exception.class)
@@ -72,8 +65,12 @@ public class BaseRestRouteBuilder extends EndpointRouteBuilder {
             .logStackTrace(true)
             .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(500))
             .setBody(constant(DefaultDocument.NULL_INSTANCE))
-            .transform(datasonnetEx("resource:classpath:exception.ds", String.class)
-                    .outputMediaType(MediaTypes.APPLICATION_JSON))
+            .transform(datasonnet("resource:classpath:exception.ds",
+                       String.class,
+                       MediaTypes.ANY.toString(),
+                       MediaTypes.APPLICATION_JSON.toString()
+                      )
+            )
         ;
     }
 }

--- a/camel-openapi-archetype/src/main/archetype/src/main/java/CamelApplication.java
+++ b/camel-openapi-archetype/src/main/archetype/src/main/java/CamelApplication.java
@@ -1,9 +1,5 @@
 package ${package};
 
-import io.jaegertracing.Configuration;
-import org.apache.camel.opentracing.OpenTracingTracer;
-import org.apache.camel.tracing.Tracer;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -23,13 +19,5 @@ public class CamelApplication {
      */
     public static void main(String[] args) {
         SpringApplication.run(CamelApplication.class, args);
-    }
-
-    @Bean
-    public Tracer tracer(@Value("#[[${JAEGER_SERVICE_NAME:${spring.application.name}}]]#") String serviceName) {
-        OpenTracingTracer answer = new OpenTracingTracer();
-        answer.setTracer(Configuration.fromEnv(serviceName).getTracer());
-
-        return answer;
     }
 }

--- a/camel-openapi-archetype/src/main/archetype/src/main/java/CamelApplication.java
+++ b/camel-openapi-archetype/src/main/archetype/src/main/java/CamelApplication.java
@@ -3,6 +3,8 @@ package ${package};
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.apache.camel.opentelemetry.OpenTelemetryTracer;
+import org.apache.camel.opentelemetry.starter.CamelOpenTelemetry;
 
 /**
  * This is the application class and main() entry point for a Spring Boot/Camel application.
@@ -10,6 +12,7 @@ import org.springframework.context.annotation.Bean;
  * @author Maven Archetype (camel-oas-archetype)
  */
 @SpringBootApplication
+@CamelOpenTelemetry
 public class CamelApplication {
 
     /**

--- a/camel-openapi-archetype/src/main/archetype/src/main/java/CamelApplication.java
+++ b/camel-openapi-archetype/src/main/archetype/src/main/java/CamelApplication.java
@@ -1,10 +1,8 @@
 package ${package};
 
+import org.apache.camel.opentelemetry.starter.CamelOpenTelemetry;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.apache.camel.opentelemetry.OpenTelemetryTracer;
-import org.apache.camel.opentelemetry.starter.CamelOpenTelemetry;
 
 /**
  * This is the application class and main() entry point for a Spring Boot/Camel application.

--- a/camel-openapi-archetype/src/main/archetype/src/main/java/RoutesImplementation.java
+++ b/camel-openapi-archetype/src/main/archetype/src/main/java/RoutesImplementation.java
@@ -1,7 +1,6 @@
 package ${package};
 
 import com.datasonnet.document.MediaTypes;
-import org.apache.camel.language.datasonnet.DatasonnetExpression;
 import org.springframework.stereotype.Component;
 
 /**

--- a/camel-openapi-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/camel-openapi-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -56,7 +55,7 @@ if (isSample) {
 }
 
 def generatedApiDirectory = request.outputDirectory + "/" + request.artifactId
-def camelRestDslPluginVersion = '0.1.7'
+def camelRestDslPluginVersion = '0.1.8-SNAPSHOT'
 def mvnCommand = ['mvn', 'com.ms3-inc.tavros:camel-restdsl-openapi-plugin:' + camelRestDslPluginVersion + ':generate', '-DspecificationUri=' + specUri, '-f', generatedApiDirectory]
 
 if (Files.exists(Path.of(specUri))) {

--- a/camel-openapi-archetype/src/test/resources/settings.xml
+++ b/camel-openapi-archetype/src/test/resources/settings.xml
@@ -21,9 +21,9 @@
                       https://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
         <server>
-            <id>github-snapshots</id>
-            <username>${env.REPO_USER}</username>
-            <password>${env.REPO_PASSWORD}</password>
+            <id>github-ms3-extensions</id>
+            <username>${env.GH_USERNAME}</username>
+            <password>${env.GH_PAT}</password>
         </server>
     </servers>
     <activeProfiles>
@@ -34,15 +34,10 @@
             <id>it</id>
             <repositories>
                 <repository>
+                    <id>github-ms3-extensions</id>
                     <snapshots>
-                        <enabled>false</enabled>
+                        <enabled>true</enabled>
                     </snapshots>
-                    <id>github-releases</id>
-                    <url>https://maven.pkg.github.com/ms3inc/camel-rest-extensions</url>
-                </repository>
-                <repository>
-                    <snapshots/>
-                    <id>github-snapshots</id>
                     <url>https://maven.pkg.github.com/ms3inc/camel-rest-extensions</url>
                 </repository>
             </repositories>

--- a/camel-openapi-archetype/src/test/resources/settings.xml
+++ b/camel-openapi-archetype/src/test/resources/settings.xml
@@ -19,6 +19,13 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                       https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>github-snapshots</id>
+            <username>${env.REPO_USER}</username>
+            <password>${env.REPO_PASSWORD}</password>
+        </server>
+    </servers>
     <activeProfiles>
         <activeProfile>it</activeProfile>
     </activeProfiles>
@@ -30,15 +37,13 @@
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>
-                    <id>ms3-releases</id>
-                    <name>maven-releases</name>
-                    <url>https://maven.ms3-inc.com/repository/maven-releases/</url>
+                    <id>github-releases</id>
+                    <url>https://maven.pkg.github.com/ms3inc/camel-rest-extensions</url>
                 </repository>
                 <repository>
                     <snapshots/>
-                    <id>ms3-snapshots</id>
-                    <name>maven-snapshots</name>
-                    <url>https://maven.ms3-inc.com/repository/maven-snapshots/</url>
+                    <id>github-snapshots</id>
+                    <url>https://maven.pkg.github.com/ms3inc/camel-rest-extensions</url>
                 </repository>
             </repositories>
         </profile>

--- a/camel-scheduled-archetype/pom.xml
+++ b/camel-scheduled-archetype/pom.xml
@@ -64,14 +64,12 @@
 
 	<distributionManagement>
 		<repository>
-			<id>ms3-nexus</id>
-			<name>maven-releases</name>
-			<url>https://maven.ms3-inc.com/repository/maven-releases/</url>
+			<id>github-arch-snapshots</id>
+			<url>https://maven.pkg.github.com/ms3inc/camel-archetypes</url>
 		</repository>
 		<snapshotRepository>
-			<id>ms3-nexus</id>
-			<name>maven-snapshots</name>
-			<url>https://maven.ms3-inc.com/repository/maven-snapshots/</url>
+			<id>github-arch-snapshots</id>
+			<url>https://maven.pkg.github.com/ms3inc/camel-archetypes</url>
 		</snapshotRepository>
 	</distributionManagement>
 

--- a/camel-scheduled-archetype/pom.xml
+++ b/camel-scheduled-archetype/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2020-2021 the original author or authors.
+    Copyright 2020-2024 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/camel-scheduled-archetype/pom.xml
+++ b/camel-scheduled-archetype/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.ms3-inc.tavros</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.2.8-SNAPSHOT</version>
+        <version>0.2.9-SNAPSHOT</version>
     </parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/camel-scheduled-archetype/src/main/archetype/Dockerfile
+++ b/camel-scheduled-archetype/src/main/archetype/Dockerfile
@@ -1,13 +1,13 @@
-FROM adoptopenjdk/openjdk11:alpine-jre as builder
+FROM eclipse-temurin:21-jre-alpine as builder
 WORKDIR application
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR application
 COPY --from=builder application/dependencies/ ./
 COPY --from=builder application/spring-boot-loader/ ./
 COPY --from=builder application/snapshot-dependencies/ ./
 COPY --from=builder application/application/ ./
-ENTRYPOINT ["java", "-XX:MinRAMPercentage=50.0", "-XX:MaxRAMPercentage=90.0", "org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java", "-XX:MinRAMPercentage=50.0", "-XX:MaxRAMPercentage=90.0", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/camel-scheduled-archetype/src/main/archetype/pom.xml
+++ b/camel-scheduled-archetype/src/main/archetype/pom.xml
@@ -14,8 +14,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <spring-boot.version>3.2.4</spring-boot.version>
         <camel.version>4.5.0</camel.version>
         <opentelemetry-agent.version>1.25.1</opentelemetry-agent.version>

--- a/camel-scheduled-archetype/src/main/archetype/pom.xml
+++ b/camel-scheduled-archetype/src/main/archetype/pom.xml
@@ -16,17 +16,17 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <spring-boot.version>2.3.2.RELEASE</spring-boot.version>
-        <camel.version>3.7.1</camel.version>
+        <spring-boot.version>3.2.4</spring-boot.version>
+        <camel.version>4.5.0</camel.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!-- override log4j, related to CVE-2021-45105, CVE-2021-45046 and CVE-2021-44228 -->
+            <!-- Override Log4j2, related to https://github.com/spring-projects/spring-boot/issues/33450 -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
-                <version>2.17.0</version>
+                <version>3.0.0-beta1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -45,18 +45,6 @@
                 <version>${camel.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <!-- override camel's scala version -->
-            <dependency>
-                <groupId>org.scala-lang</groupId>
-                <artifactId>scala-library</artifactId>
-                <version>2.13.3</version>
-            </dependency>
-            <!-- override camel's datasonnet -->
-            <dependency>
-                <groupId>com.datasonnet</groupId>
-                <artifactId>datasonnet-mapper</artifactId>
-                <version>2.1.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -130,28 +118,13 @@
             <groupId>com.ms3-inc.tavros</groupId>
             <artifactId>camel-rest-extensions</artifactId>
             <version>0.1.6</version>
-        </dependency>
-
-        <!-- OpenTracing deps -->
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-opentracing-starter</artifactId>
             <exclusions>
+                <!-- https://github.com/spring-projects/spring-framework/issues/20611 -->
                 <exclusion>
-                    <groupId>org.apache.camel</groupId>
-                    <artifactId>camel-opentracing</artifactId>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.ms3-inc.tavros</groupId>
-            <artifactId>camel-opentracing</artifactId>
-            <version>${camel.version}-002</version>
-        </dependency>
-        <dependency>
-            <groupId>io.jaegertracing</groupId>
-            <artifactId>jaeger-client</artifactId>
-            <version>1.5.0</version>
         </dependency>
 
         <!-- Test -->

--- a/camel-scheduled-archetype/src/main/archetype/pom.xml
+++ b/camel-scheduled-archetype/src/main/archetype/pom.xml
@@ -18,6 +18,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <spring-boot.version>3.2.4</spring-boot.version>
         <camel.version>4.5.0</camel.version>
+        <opentelemetry-agent.version>1.25.1</opentelemetry-agent.version>
     </properties>
 
     <dependencyManagement>
@@ -127,6 +128,11 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-opentelemetry-starter</artifactId>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -185,12 +191,43 @@
                     <layers>
                         <enabled>true</enabled>
                     </layers>
+                    <agents>
+                        <agent>${project.build.directory}/javaagents/javaagent.jar</agent>
+                    </agents>
+                    <environmentVariables>
+                        <OTEL_SERVICE_NAME>${project.artifactId}</OTEL_SERVICE_NAME>
+                    </environmentVariables>
                 </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>repackage</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-javaagent</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry-agent.version}</version>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/javaagents</outputDirectory>
+                                    <destFileName>javaagent.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/camel-scheduled-archetype/src/main/archetype/pom.xml
+++ b/camel-scheduled-archetype/src/main/archetype/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
-            <version>3.4.2</version>
+            <version>4.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/camel-scheduled-archetype/src/main/archetype/pom.xml
+++ b/camel-scheduled-archetype/src/main/archetype/pom.xml
@@ -16,8 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring-boot.version>3.2.4</spring-boot.version>
-        <camel.version>4.5.0</camel.version>
+        <spring-boot.version>3.3.0</spring-boot.version>
+        <camel.version>4.4.3</camel.version>
         <opentelemetry-agent.version>1.25.1</opentelemetry-agent.version>
     </properties>
 

--- a/camel-scheduled-archetype/src/main/archetype/src/main/java/BaseRouteBuilder.java
+++ b/camel-scheduled-archetype/src/main/archetype/src/main/java/BaseRouteBuilder.java
@@ -19,16 +19,6 @@ import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
  * @author Maven Archetype (camel-oas-archetype)
  */
 public class BaseRouteBuilder extends EndpointRouteBuilder {
-    protected DatasonnetExpression datasonnetEx(String expression) {
-        return (DatasonnetExpression) getContext().resolveLanguage("datasonnet").createExpression(expression);
-    }
-
-    protected DatasonnetExpression datasonnetEx(String expression, Class<?> resultType) {
-        Object[] properties = new Object[3];
-        properties[0] = resultType;
-        return (DatasonnetExpression) getContext().resolveLanguage("datasonnet").createExpression(expression, properties);
-    }
-
     @Override
     public void configure() throws Exception {
 
@@ -39,8 +29,12 @@ public class BaseRouteBuilder extends EndpointRouteBuilder {
             .logStackTrace(true)
             .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(500))
             .setBody(constant(DefaultDocument.NULL_INSTANCE))
-            .transform(datasonnetEx("resource:classpath:exception.ds", String.class)
-                    .outputMediaType(MediaTypes.APPLICATION_JSON))
+            .transform(datasonnet("resource:classpath:exception.ds",
+                       String.class,
+                       MediaTypes.ANY.toString(),
+                       MediaTypes.APPLICATION_JSON.toString()
+                    )
+            )
         ;
     }
 }

--- a/camel-scheduled-archetype/src/main/archetype/src/main/java/BaseRouteBuilder.java
+++ b/camel-scheduled-archetype/src/main/archetype/src/main/java/BaseRouteBuilder.java
@@ -3,7 +3,6 @@ package ${package};
 import com.datasonnet.document.DefaultDocument;
 import com.datasonnet.document.Document;
 import com.datasonnet.document.MediaTypes;
-import org.apache.camel.language.datasonnet.DatasonnetExpression;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
 

--- a/camel-scheduled-archetype/src/main/archetype/src/main/java/CamelApplication.java
+++ b/camel-scheduled-archetype/src/main/archetype/src/main/java/CamelApplication.java
@@ -1,9 +1,5 @@
 package ${package};
 
-import io.jaegertracing.Configuration;
-import org.apache.camel.opentracing.OpenTracingTracer;
-import org.apache.camel.tracing.Tracer;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -23,13 +19,5 @@ public class CamelApplication {
      */
     public static void main(String[] args) {
         SpringApplication.run(CamelApplication.class, args);
-    }
-
-    @Bean
-    public Tracer tracer(@Value("#[[${JAEGER_SERVICE_NAME:${spring.application.name:unknown-camel}}]]#") String serviceName) {
-        OpenTracingTracer answer = new OpenTracingTracer();
-        answer.setTracer(Configuration.fromEnv(serviceName).getTracer());
-
-        return answer;
     }
 }

--- a/camel-scheduled-archetype/src/main/archetype/src/main/java/CamelApplication.java
+++ b/camel-scheduled-archetype/src/main/archetype/src/main/java/CamelApplication.java
@@ -3,6 +3,8 @@ package ${package};
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.apache.camel.opentelemetry.OpenTelemetryTracer;
+import org.apache.camel.opentelemetry.starter.CamelOpenTelemetry;
 
 /**
  * This is the application class and main() entry point for a Spring Boot/Camel application.
@@ -10,6 +12,7 @@ import org.springframework.context.annotation.Bean;
  * @author Maven Archetype (camel-oas-archetype)
  */
 @SpringBootApplication
+@CamelOpenTelemetry
 public class CamelApplication {
 
     /**

--- a/camel-scheduled-archetype/src/main/archetype/src/main/java/CamelApplication.java
+++ b/camel-scheduled-archetype/src/main/archetype/src/main/java/CamelApplication.java
@@ -1,10 +1,8 @@
 package ${package};
 
+import org.apache.camel.opentelemetry.starter.CamelOpenTelemetry;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.apache.camel.opentelemetry.OpenTelemetryTracer;
-import org.apache.camel.opentelemetry.starter.CamelOpenTelemetry;
 
 /**
  * This is the application class and main() entry point for a Spring Boot/Camel application.

--- a/camel-scheduled-archetype/src/main/archetype/src/main/java/RoutesScheduled.java
+++ b/camel-scheduled-archetype/src/main/archetype/src/main/java/RoutesScheduled.java
@@ -1,7 +1,5 @@
 package ${package};
 
-import javax.annotation.Generated;
-
 import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
 import org.springframework.stereotype.Component;
 
@@ -12,7 +10,6 @@ import org.springframework.stereotype.Component;
  *
  * @author Maven Archetype (camel-scheduled-archetype)
  */
-@Generated("com.ms3inc.camel-oas-archetype")
 @Component
 public class RoutesScheduled extends EndpointRouteBuilder {
 

--- a/camel-scheduled-archetype/src/test/resources/settings.xml
+++ b/camel-scheduled-archetype/src/test/resources/settings.xml
@@ -25,22 +25,6 @@
     <profiles>
         <profile>
             <id>it</id>
-            <repositories>
-                <repository>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                    <id>ms3-releases</id>
-                    <name>maven-releases</name>
-                    <url>https://maven.ms3-inc.com/repository/maven-releases/</url>
-                </repository>
-                <repository>
-                    <snapshots/>
-                    <id>ms3-snapshots</id>
-                    <name>maven-snapshots</name>
-                    <url>https://maven.ms3-inc.com/repository/maven-snapshots/</url>
-                </repository>
-            </repositories>
         </profile>
     </profiles>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ms3-inc.tavros</groupId>
     <artifactId>archetypes</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.9-SNAPSHOT</version>
     <packaging>pom</packaging>
     <inceptionYear>2020</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
             <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
-            <id>ms3-nexus</id>
+            <id>github-arch-snapshots</id>
             <name>maven-snapshots</name>
             <url>https://maven.ms3-inc.com/repository/maven-snapshots/</url>
         </snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2020-2021 the original author or authors.
+    Copyright 2020-2024 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <snapshotRepository>
             <id>github-arch-snapshots</id>
             <name>maven-snapshots</name>
-            <url>https://maven.ms3-inc.com/repository/maven-snapshots/</url>
+            <url>https://maven.pkg.github.com/ms3inc/camel-archetypes</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
# Reason for PR

A client needs to utilize the latest version of the archetype with the fixed Camel DS version, and merging to main will enable easier maintenance/linking to this repo.

I have not had a chance to test this with Tavros, but since there are likely other aspects that are out of date at this point, I think keeping this repo up to date is more important at the moment.

The Open Telemetry stuff is the only stuff that I foresee as a breaking change, and I think Tavros could be changed to support this if it's ever updated.

## Overview of Changes

Tested changes:
- Change snapshot releases to be from ms3 maven to github, triggered by manual release
- Update to SB 3.3.0 (LTS)
- Update to Camel 4.4.3 (LTS to fix [memory issue that causes DS expressions to stop working until restart](https://issues.apache.org/jira/browse/CAMEL-20841))
- Dockerfile updated to use Java 21
- A number of other dependency changes in the pom to support the above changes
- `datasonnet()` now replaces usages of `datasonnetEx()` or `DatasonnetExpression.builder()`. Examples are in BaseRestRouteBuilder and RoutesImplementation.

Untested Tavros changes:
- Spans/tracing fixed, works with local jaeger provided otel config and docker is setup correctly

### Manual Acceptance Tests of generated archetype

To test:
- generate a project without a specificationUri to use the provided OAS
- generate a project with a downloaded [Pet Store spec](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)

### Tests for default OAS

**Confirm ready - PASSING**  
curl 'http://localhost:8080/actuator/health/readiness'

**Confirm GET works - PASSING**  
curl 'http://localhost:9000/api/hello'

**Confirm POST works - PASSING**  
```
curl --location --request POST 'localhost:9000/api/greeting' \
--header 'Content-Type: application/json' \
--data-raw '{
    "caller":"other"
}'
```

**Confirm main exception handling works - PASSING**  
example: .throwException(new ArithmeticException())

**Confirm RestException returns correctly - PASSING**  
```
curl --location --request POST 'localhost:9000/api/greeting' \
--header 'Content-Type: application/json' \
--data-raw '{
    "wrongProp":"other"
}'
```

**Confirm logs contain unique span and trace ids inside of the MDC by adding a log on any of the routes - PASSING**  
**Confirm traces can be seen in Jaeger, and GET /hello shows as 4 spans - PASSING**